### PR TITLE
Fix: Remove useless DocBlocks from class properties

### DIFF
--- a/src/FrozenClock.php
+++ b/src/FrozenClock.php
@@ -15,9 +15,6 @@ namespace Localheinz\Clock;
 
 final class FrozenClock implements ClockInterface
 {
-    /**
-     * @var \DateTimeImmutable
-     */
     private $now;
 
     public function __construct(\DateTimeImmutable $now)

--- a/src/SystemClock.php
+++ b/src/SystemClock.php
@@ -15,9 +15,6 @@ namespace Localheinz\Clock;
 
 final class SystemClock implements ClockInterface
 {
-    /**
-     * @var \DateTimeZone
-     */
     private $timezone;
 
     public function __construct(\DateTimeZone $timezone)


### PR DESCRIPTION
This PR

* [x] removes useless DocBlocks from class properties